### PR TITLE
fix MSVC build error

### DIFF
--- a/lite/ort/cv/deeplabv3_resnet101.cpp
+++ b/lite/ort/cv/deeplabv3_resnet101.cpp
@@ -4,6 +4,7 @@
 
 #include "deeplabv3_resnet101.h"
 #include "lite/ort/core/ort_utils.h"
+#include "lite/utils.h"
 
 using ortcv::DeepLabV3ResNet101;
 

--- a/lite/ort/cv/faceboxes.cpp
+++ b/lite/ort/cv/faceboxes.cpp
@@ -90,7 +90,7 @@ void FaceBoxes::generate_anchors(const int target_height,
                 // (x or y + offset) * step / w or h normalized loc mapping to input size.
                 float cx = ((float) j + offset_x) * (float) steps.at(k) / (float) target_width;
                 float cy = ((float) i + offset_y) * (float) steps.at(k) / (float) target_height;
-                anchors.push_back((FaceBoxesAnchor) {cx, cy, s_kx, s_ky}); // without clip
+                anchors.push_back(FaceBoxesAnchor{cx, cy, s_kx, s_ky}); // without clip
               }
             }
 
@@ -104,7 +104,7 @@ void FaceBoxes::generate_anchors(const int target_height,
               {
                 float cx = ((float) j + offset_x) * (float) steps.at(k) / (float) target_width;
                 float cy = ((float) i + offset_y) * (float) steps.at(k) / (float) target_height;
-                anchors.push_back((FaceBoxesAnchor) {cx, cy, s_kx, s_ky}); // without clip
+                anchors.push_back(FaceBoxesAnchor{cx, cy, s_kx, s_ky}); // without clip
               }
             }
 
@@ -113,7 +113,7 @@ void FaceBoxes::generate_anchors(const int target_height,
           {
             float cx = ((float) j + 0.5f) * (float) steps.at(k) / (float) target_width;
             float cy = ((float) i + 0.5f) * (float) steps.at(k) / (float) target_height;
-            anchors.push_back((FaceBoxesAnchor) {cx, cy, s_kx, s_ky}); // without clip
+            anchors.push_back(FaceBoxesAnchor{cx, cy, s_kx, s_ky}); // without clip
           }
         }
       }

--- a/lite/ort/cv/fcn_resnet101.cpp
+++ b/lite/ort/cv/fcn_resnet101.cpp
@@ -4,6 +4,7 @@
 
 #include "fcn_resnet101.h"
 #include "lite/ort/core/ort_utils.h"
+#include "lite/utils.h"
 
 using ortcv::FCNResNet101;
 

--- a/lite/ort/cv/pose_robust_face.cpp
+++ b/lite/ort/cv/pose_robust_face.cpp
@@ -4,6 +4,7 @@
 
 #include "pose_robust_face.h"
 #include "lite/ort/core/ort_utils.h"
+#include "lite/utils.h"
 
 using ortcv::PoseRobustFace;
 

--- a/lite/ort/cv/retinaface.cpp
+++ b/lite/ort/cv/retinaface.cpp
@@ -83,7 +83,7 @@ void RetinaFace::generate_anchors(const int target_height,
           float cx = ((float) j + 0.5f) * (float) steps.at(k) / (float) target_width;
           float cy = ((float) i + 0.5f) * (float) steps.at(k) / (float) target_height;
 
-          anchors.push_back((RetinaAnchor) {cx, cy, s_kx, s_ky}); // without clip
+          anchors.push_back(RetinaAnchor{cx, cy, s_kx, s_ky}); // without clip
         }
       }
     }

--- a/lite/ort/cv/rvm.cpp
+++ b/lite/ort/cv/rvm.cpp
@@ -4,6 +4,7 @@
 
 #include "rvm.h"
 #include "lite/ort/core/ort_utils.h"
+#include "lite/utils.h"
 
 using ortcv::RobustVideoMatting;
 

--- a/lite/ort/cv/tiny_yolov3.cpp
+++ b/lite/ort/cv/tiny_yolov3.cpp
@@ -4,6 +4,7 @@
 
 #include "tiny_yolov3.h"
 #include "lite/ort/core/ort_utils.h"
+#include "lite/utils.h"
 
 using ortcv::TinyYoloV3;
 

--- a/lite/ort/cv/yolov3.cpp
+++ b/lite/ort/cv/yolov3.cpp
@@ -4,6 +4,7 @@
 
 #include "yolov3.h"
 #include "lite/ort/core/ort_utils.h"
+#include "lite/utils.h"
 
 using ortcv::YoloV3;
 

--- a/lite/types.h
+++ b/lite/types.h
@@ -49,11 +49,11 @@ namespace lite {
 
       value_type area() const;
 
-      cv::Rect rect() const;
+      ::cv::Rect rect() const;
 
-      cv::Point2i tl() const;
+      ::cv::Point2i tl() const;
 
-      cv::Point2i rb() const;
+      ::cv::Point2i rb() const;
 
       BoundingBoxType() :
           x1(static_cast<value_type>(0)), y1(static_cast<value_type>(0)),
@@ -260,27 +260,27 @@ lite::types::BoundingBoxType<T1, T2>::iou_of(const BoundingBoxType<O1, O2> &othe
 }
 
 template<typename T1, typename T2>
-inline cv::Rect lite::types::BoundingBoxType<T1, T2>::rect() const
+inline ::cv::Rect lite::types::BoundingBoxType<T1, T2>::rect() const
 {
   types::__assert_type<value_type, score_type>();
   auto boxi = this->template convert_type<int>();
-  return cv::Rect(boxi.x1, boxi.y1, boxi.width(), boxi.height());
+  return ::cv::Rect(boxi.x1, boxi.y1, boxi.width(), boxi.height());
 }
 
 template<typename T1, typename T2>
-inline cv::Point2i lite::types::BoundingBoxType<T1, T2>::tl() const
+inline ::cv::Point2i lite::types::BoundingBoxType<T1, T2>::tl() const
 {
   types::__assert_type<value_type, score_type>();
   auto boxi = this->template convert_type<int>();
-  return cv::Point2i(boxi.x1, boxi.y1);
+  return ::cv::Point2i(boxi.x1, boxi.y1);
 }
 
 template<typename T1, typename T2>
-inline cv::Point2i lite::types::BoundingBoxType<T1, T2>::rb() const
+inline ::cv::Point2i lite::types::BoundingBoxType<T1, T2>::rb() const
 {
   types::__assert_type<value_type, score_type>();
   auto boxi = this->template convert_type<int>();
-  return cv::Point2i(boxi.x2, boxi.y2);
+  return ::cv::Point2i(boxi.x2, boxi.y2);
 }
 
 template<typename T1, typename T2>


### PR DESCRIPTION
编译命令:
```
cd build
cmake -DINCLUDE_OPENCV=ON -DENABLE_MNN=OFF -DENABLE_NCNN=OFF -DENABLE_TNN=OFF ..
cmake --build . --config MinSizeRel
```
使用 VS2022 (v143) 工具链测试成功编译。

主要有下列三种错误:
1. `deeplabv3_resnet101.cpp(14,35): error C2039: 'utils': is not a member of 'lite'`
解决方案: `#include "lite/utils.h"`
2. `faceboxes.cpp(93,72): error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax`
解决方案: `anchors.push_back((FaceBoxesAnchor) {cx, cy, s_kx, s_ky});` -> `anchors.push_back(FaceBoxesAnchor{cx, cy, s_kx, s_ky});`
3. `types.h(263,12): error C2039: 'Rect': is not a member of 'lite::cv'`
解决方案: `cv::Rect` -> `::cv::Rect`