### PR TITLE
[TRT] Support RealESRGAN

### DIFF
--- a/examples/lite/cv/test_lite_realesrgan.cpp
+++ b/examples/lite/cv/test_lite_realesrgan.cpp
@@ -20,9 +20,30 @@ static void test_default()
 }
 
 
+static void test_tensorrt()
+{
+#ifdef ENABLE_TENSORRT
+    std::string engine_path = "../../../examples/hub/trt/RealESRGAN_x4plus_fp16.engine";
+    std::string test_img_path = "../../../examples/lite/resources/test_lite_realesrgan.jpg";
+    std::string save_img_path = "../../../examples/logs/test_lite_realesrgan_trt.jpg";
+
+    lite::trt::cv::upscale::RealESRGAN *realesrgan = new lite::trt::cv::upscale::RealESRGAN (engine_path);
+
+    cv::Mat test_image = cv::imread(test_img_path);
+
+    realesrgan->detect(test_image,save_img_path);
+
+    std::cout<<"trt upscale enhance done!"<<std::endl;
+
+    delete realesrgan;
+#endif
+}
+
+
 static void test_lite()
 {
-    test_default();
+//    test_default();
+    test_tensorrt();
 }
 
 int main(__unused int argc, __unused char *argv[])

--- a/examples/lite/cv/test_lite_realesrgan.cpp
+++ b/examples/lite/cv/test_lite_realesrgan.cpp
@@ -42,7 +42,7 @@ static void test_tensorrt()
 
 static void test_lite()
 {
-//    test_default();
+    test_default();
     test_tensorrt();
 }
 

--- a/lite/models.h
+++ b/lite/models.h
@@ -134,6 +134,7 @@
 #include "lite/trt/cv/trt_yolov6.h"
 #include "lite/trt/cv/trt_yolov5_blazeface.h"
 #include "lite/trt/cv/trt_lightenhance.h"
+#include "lite/trt/cv/trt_realesrgan.h"
 #include "lite/trt/sd/trt_clip.h"
 #include "lite/trt/sd/trt_vae.h"
 #include "lite/trt/sd/trt_unet.h"
@@ -729,6 +730,7 @@ namespace lite{
             typedef trtcv::TRTYoloV6 _TRT_YOLOv6;
             typedef trtcv::TRTYOLO5Face _TRT_YOLO5Face;
             typedef trtcv::TRTLightEnhance _TRT_LightEnhance;
+            typedef trtcv::TRTRealESRGAN _TRT_RealESRGAN;
             namespace classification
             {
 
@@ -751,6 +753,10 @@ namespace lite{
             namespace lightenhance
             {
                 typedef _TRT_LightEnhance LightEnhance;
+            }
+            namespace upscale
+            {
+                typedef _TRT_RealESRGAN RealESRGAN;
             }
         }
 

--- a/lite/trt/cv/trt_realesrgan.cpp
+++ b/lite/trt/cv/trt_realesrgan.cpp
@@ -1,0 +1,109 @@
+//
+// Created by wangzijian on 10/25/24.
+//
+
+#include "trt_realesrgan.h"
+using trtcv::TRTRealESRGAN;
+
+void TRTRealESRGAN::preprocess(const cv::Mat &frame, cv::Mat &output_mat) {
+    cv::cvtColor(frame,output_mat,cv::COLOR_BGR2RGB);
+    output_mat.convertTo(output_mat,CV_32FC3,1 / 255.f);
+}
+
+
+void TRTRealESRGAN::detect(const cv::Mat &input_mat, const std::string &output_path) {
+    if (input_mat.empty()) return;
+
+    ori_input_width = input_mat.cols;
+    ori_input_height = input_mat.rows;
+
+    cv::Mat preprocessed_mat;
+    preprocess(input_mat, preprocessed_mat);
+
+    const int batch_size = 1;
+    const int channels = 3;
+    const int input_h = preprocessed_mat.rows;
+    const int input_w = preprocessed_mat.cols;
+    const size_t input_size = batch_size * channels * input_h * input_w * sizeof(float);
+    const size_t output_size = batch_size * channels * input_h * 4 * input_w * 4 * sizeof(float);
+
+    for (auto& buffer : buffers) {
+        if (buffer) {
+            cudaFree(buffer);
+            buffer = nullptr;
+        }
+    }
+
+    cudaMalloc(&buffers[0], input_size);
+    cudaMalloc(&buffers[1], output_size);
+    if (!buffers[0] || !buffers[1]) {
+        std::cerr << "Failed to allocate CUDA memory" << std::endl;
+        return;
+    }
+
+    input_node_dims = {batch_size, channels, input_h, input_w};
+
+    std::vector<float> input;
+    trtcv::utils::transform::create_tensor(preprocessed_mat, input, input_node_dims, trtcv::utils::transform::CHW);
+
+    cudaError_t status = cudaMemcpyAsync(buffers[0], input.data(), input_size,
+                                         cudaMemcpyHostToDevice, stream);
+    if (status != cudaSuccess) {
+        std::cerr << "Input copy failed: " << cudaGetErrorString(status) << std::endl;
+        return;
+    }
+    cudaStreamSynchronize(stream);
+
+    nvinfer1::Dims ESRGANDims;
+    ESRGANDims.nbDims = 4;
+    ESRGANDims.d[0] = batch_size;
+    ESRGANDims.d[1] = channels;
+    ESRGANDims.d[2] = input_h;
+    ESRGANDims.d[3] = input_w;
+
+    auto input_tensor_name = trt_engine->getIOTensorName(0);
+    auto output_tensor_name = trt_engine->getIOTensorName(1);
+    trt_context->setTensorAddress(input_tensor_name, buffers[0]);
+    trt_context->setTensorAddress(output_tensor_name, buffers[1]);
+
+    trt_context->setInputShape(input_tensor_name, ESRGANDims);
+
+    bool infer_status = trt_context->enqueueV3(stream);
+    if (!infer_status) {
+        std::cerr << "TensorRT inference failed!" << std::endl;
+        return;
+    }
+    cudaStreamSynchronize(stream);
+
+    const size_t total_output_elements = batch_size * channels * input_h * 4 * input_w * 4;
+    std::vector<float> output(total_output_elements);
+
+    status = cudaMemcpyAsync(output.data(), buffers[1], output_size,
+                             cudaMemcpyDeviceToHost, stream);
+    if (status != cudaSuccess) {
+        std::cerr << "Output copy failed: " << cudaGetErrorString(status) << std::endl;
+        return;
+    }
+    cudaStreamSynchronize(stream);
+
+    postprocess(output.data(), output_path);
+}
+
+void TRTRealESRGAN::postprocess(float *trt_outputs, const std::string &output_path) {
+    const int out_h = ori_input_height * 4;
+    const int out_w = ori_input_width * 4;
+    const int channel_step = out_h * out_w;
+    cv::Mat bmat(out_h, out_w, CV_32FC1, trt_outputs);
+    cv::Mat gmat(out_h, out_w, CV_32FC1, trt_outputs + channel_step);
+    cv::Mat rmat(out_h, out_w, CV_32FC1, trt_outputs + 2 * channel_step);
+    bmat *= 255.f;
+    gmat *= 255.f;
+    rmat *= 255.f;
+    std::vector<cv::Mat> channel_mats = {rmat, gmat, bmat};
+    cv::Mat dstimg;
+    cv::merge(channel_mats,dstimg);
+    dstimg.convertTo(dstimg, CV_8UC3);
+    cv::imwrite(output_path,dstimg);
+}
+
+

--- a/lite/trt/cv/trt_realesrgan.h
+++ b/lite/trt/cv/trt_realesrgan.h
@@ -1,0 +1,27 @@
+
+//
+// Created by wangzijian on 10/25/24.
+//
+
+#ifndef LITE_AI_TOOLKIT_TRT_REALESRGAN_H
+#define LITE_AI_TOOLKIT_TRT_REALESRGAN_H
+#include "lite/trt/core/trt_core.h"
+#include "lite/trt/core/trt_utils.h"
+
+namespace trtcv{
+    class LITE_EXPORTS TRTRealESRGAN : public BasicTRTHandler{
+    public:
+        explicit TRTRealESRGAN(const std::string& _trt_model_path,unsigned int _num_threads = 1):
+                BasicTRTHandler(_trt_model_path, _num_threads){};
+
+    private:
+        int ori_input_width;
+        int ori_input_height;
+        void preprocess(const cv::Mat& frame,cv::Mat &output_mat);
+        void postprocess(float *trt_outputs,const std::string &output_path);
+    public:
+        void detect(const cv::Mat &input_mat,const std::string &output_path);
+    };
+}
+
+#endif //LITE_AI_TOOLKIT_TRT_REALESRGAN_H


### PR DESCRIPTION
This pull request introduces support for TensorRT-based Real-ESRGAN upscaling in the `lite` module. The most important changes include the addition of a new test function, updates to the `models.h` file to include the new model, and the implementation of the Real-ESRGAN class for TensorRT.

### TensorRT Real-ESRGAN Integration:

* **New Test Function:**
  * Added `test_tensorrt()` function in `test_lite_realesrgan.cpp` to test TensorRT-based Real-ESRGAN upscaling. (`examples/lite/cv/test_lite_realesrgan.cpp`, [examples/lite/cv/test_lite_realesrgan.cppR23-R46](diffhunk://#diff-dfcdfa92a7409224fd520b6ea78329fb84cd70e54275ab609fe22c981d0c1fa9R23-R46))

* **Model Header Updates:**
  * Included `trt_realesrgan.h` in the `models.h` file. (`lite/models.h`, [lite/models.hR137](diffhunk://#diff-80805648b47990fbf2c14ee25216641075e717ce1157a36d0089ab5108b89112R137))
  * Added typedef for `TRTRealESRGAN` and nested it within the `upscale` namespace. (`lite/models.h`, [[1]](diffhunk://#diff-80805648b47990fbf2c14ee25216641075e717ce1157a36d0089ab5108b89112R733) [[2]](diffhunk://#diff-80805648b47990fbf2c14ee25216641075e717ce1157a36d0089ab5108b89112R757-R760)

* **Real-ESRGAN Implementation:**
  * Implemented the `TRTRealESRGAN` class with methods for preprocessing, detection, and postprocessing in `trt_realesrgan.cpp`. (`lite/trt/cv/trt_realesrgan.cpp`, [lite/trt/cv/trt_realesrgan.cppR1-R109](diffhunk://#diff-af098fa90553870cdf15c07700b157f8f4790c6c2dc056171040ebb03aa32829R1-R109))
  * Defined the `TRTRealESRGAN` class in the header file `trt_realesrgan.h`. (`lite/trt/cv/trt_realesrgan.h`, [lite/trt/cv/trt_realesrgan.hR1-R27](diffhunk://#diff-decbe49cd72515d1b84211ddac2e912ad7cad0c34643f93bb5d427dd61fbbbc2R1-R27))